### PR TITLE
Add missing Tailwind dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,13 @@
     "zustand": "^4.4.1",
     "clsx": "^1.2.1"
   },
-  "devDependencies": {
-    "@types/react": "^18.2.21",
-    "@types/react-dom": "^18.2.7",
-    "typescript": "^5.2.2",
-    "vite": "^4.4.0"
+    "devDependencies": {
+      "@types/react": "^18.2.21",
+      "@types/react-dom": "^18.2.7",
+      "typescript": "^5.2.2",
+      "vite": "^4.4.0",
+      "tailwindcss": "^3.3.3",
+      "postcss": "^8.4.31",
+      "autoprefixer": "^10.4.16"
+    }
   }
-}


### PR DESCRIPTION
## Summary
- include `tailwindcss`, `postcss` and `autoprefixer` so Vite can load the Tailwind config

## Testing
- `npm run build` *(fails: vite not found)*